### PR TITLE
remove the need to destructure size

### DIFF
--- a/test/src/index.js
+++ b/test/src/index.js
@@ -9,14 +9,19 @@ const pattern = [
   1, 2
 ] // R-pentomino
 
+let size = [ 256, 256 ]
 let world = Life(pattern.slice())
-let viewport = {
-  size: [ 256, 256 ],
-  position: [ 0, 0 ]
+
+let state = {
+  world,
+  viewport: {
+    position: [ 0, 0 ],
+    size
+  }
 }
 
-let state = { world, viewport }
-let view = View(...viewport.size)
+let view = View(size)
+
 document.body.appendChild(view.context.canvas)
 requestAnimationFrame(loop)
 


### PR DESCRIPTION
If you store the size you can reuse it later without spreading it from the viewport object.